### PR TITLE
Update UAT node selectors to new SGX pool nodes

### DIFF
--- a/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-gateway.yaml
+++ b/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-gateway.yaml
@@ -63,7 +63,7 @@ backend:
       cpu: 500m
       memory: 5Gi
   nodeSelector:
-      kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001u
+      kubernetes.io/hostname: aks-sgxpool-23126921-vmss000020
   tolerations: []
   affinity: {}
 

--- a/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-sequencer.yaml
+++ b/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-sequencer.yaml
@@ -9,7 +9,7 @@ enclave:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.5.6"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001s
+    kubernetes.io/hostname: aks-sgxpool-23126921-vmss000021
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -37,7 +37,7 @@ enclave02:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.5.6"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001t
+    kubernetes.io/hostname: aks-sgxpool-23126921-vmss000022
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -65,7 +65,7 @@ host:
     tag: "v1.5.6"
   fqdn: uat-testnet-sequencer.ten.xyz
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001s
+    kubernetes.io/hostname: aks-sgxpool-23126921-vmss000021
 
 config:
   network:

--- a/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-01.yaml
+++ b/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-01.yaml
@@ -8,7 +8,7 @@ enclave:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.5.6"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001t
+    kubernetes.io/hostname: aks-sgxpool-23126921-vmss000020
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -36,7 +36,7 @@ host:
     tag: "v1.5.6"
   fqdn: uat-validator-01.ten.xyz
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001t
+    kubernetes.io/hostname: aks-sgxpool-23126921-vmss000020
 
 config:
   network:

--- a/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-02.yaml
+++ b/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-02.yaml
@@ -8,7 +8,7 @@ enclave:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.5.6"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001u
+    kubernetes.io/hostname: aks-sgxpool-23126921-vmss000021
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -36,7 +36,7 @@ host:
     tag: "v1.5.6"
   fqdn: uat-validator-02.ten.xyz
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-23126921-vmss00001u
+    kubernetes.io/hostname: aks-sgxpool-23126921-vmss000021
 
 
 config:


### PR DESCRIPTION
## Summary
Updates the node selectors for all UAT environment components (enclave, host, and gateways) to use the new SGX pool nodes.

## Changes Made
- **Gateway Backend**: Moved to `aks-sgxpool-23126921-vmss000020`
- **Sequencer**: 
  - Primary enclave and host moved to `aks-sgxpool-23126921-vmss000021`
  - Secondary enclave (enclave02) moved to `aks-sgxpool-23126921-vmss000022`
- **Validator-01**: Both enclave and host moved to `aks-sgxpool-23126921-vmss000020`
- **Validator-02**: Both enclave and host moved to `aks-sgxpool-23126921-vmss000021`

## Node Distribution
- **Node 000020**: Gateway backend + Validator-01 (enclave + host) = 3 workloads
- **Node 000021**: Sequencer (primary enclave + host) + Validator-02 (enclave + host) = 4 workloads
- **Node 000022**: Sequencer enclave02 = 1 workload

## Files Modified
- `nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-gateway.yaml`
- `nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-sequencer.yaml`
- `nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-01.yaml`
- `nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-02.yaml`

## Testing
- All YAML files validated for syntax
- Node selector updates verified
- Balanced workload distribution across the three new nodes

This provides optimal distribution of UAT workloads while keeping related components (enclave + host pairs) co-located on the same nodes for best performance.