### PR TITLE
Replace obsolete bitnami/kubectl with rancher/kubectl

### DIFF
--- a/charts/ten-node/values.yaml
+++ b/charts/ten-node/values.yaml
@@ -412,8 +412,8 @@ cleanupJob:
   # Configuration for the PVC cleanup job
   pvc:
     image:
-      repository: bitnami/kubectl
-      tag: "latest"
+      repository: rancher/kubectl
+      tag: "v1.33.5"
       pullPolicy: Always
     serviceAccount:
       create: true


### PR DESCRIPTION
## Summary
Replaces the obsolete `bitnami/kubectl:latest` image with `rancher/kubectl:v1.33.5` in the ten-node chart.

## Problem
The `bitnami/kubectl` image has been deprecated and is no longer maintained, which poses security and compatibility risks.

## Solution
- Updated `charts/ten-node/values.yaml` to use `rancher/kubectl:v1.33.5`
- Changed the PVC cleanup job image configuration
- Ensures compatibility with Kubernetes v1.33.x

## Changes Made
- **Repository**: `bitnami/kubectl` → `rancher/kubectl`
- **Tag**: `latest` → `v1.33.5`
- **Location**: `cleanupJob.pvc.image` section in ten-node chart values

## Benefits
- ✅ Uses actively maintained kubectl image
- ✅ Specific version tag for reproducible builds
- ✅ Compatible with current Kubernetes versions
- ✅ Improved security posture

## Testing
- Verified no other references to bitnami/kubectl in the repository
- Chart values syntax validated