### PR TITLE
Add postgres client chart and mainnet configuration

### DIFF
--- a/charts/postgres-client/Chart.yaml
+++ b/charts/postgres-client/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: postgres-client
+description: PostgreSQL client pod for database access via terminal
+type: application
+version: 1.0.0
+appVersion: "16"

--- a/charts/postgres-client/templates/deployment.yaml
+++ b/charts/postgres-client/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-client
+  labels:
+    app: postgres-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-client
+  template:
+    metadata:
+      labels:
+        app: postgres-client
+    spec:
+      containers:
+      - name: postgres-client
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - sleep
+          - infinity
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        env:
+        - name: PGHOST
+          value: ""
+        - name: PGPORT
+          value: "5432"
+        - name: PGUSER
+          value: ""
+        - name: PGDATABASE
+          value: ""
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/postgres-client/values.yaml
+++ b/charts/postgres-client/values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: postgres
+  tag: 16-alpine
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/prod-argocd-config/apps/envs/mainnet/postgres-client-app.yaml
+++ b/prod-argocd-config/apps/envs/mainnet/postgres-client-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mainnet-postgres-client
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ten-protocol/ten-apps.git
+    targetRevision: main
+    path: charts/postgres-client
+    helm:
+      valueFiles:
+        - ../../prod-argocd-config/apps/envs/mainnet/valuesFile/values-mainnet-postgres-client.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mainnet
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/prod-argocd-config/apps/envs/mainnet/valuesFile/values-mainnet-postgres-client.yaml
+++ b/prod-argocd-config/apps/envs/mainnet/valuesFile/values-mainnet-postgres-client.yaml
@@ -1,0 +1,14 @@
+image:
+  repository: postgres
+  tag: 16-alpine
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+nodeSelector: {}


### PR DESCRIPTION
This PR adds:

- A new postgres-client Helm chart for connecting to PostgreSQL databases
- ArgoCD application configuration for mainnet environment deployment  
- Values file for mainnet postgres-client configuration

The postgres-client chart provides a configurable way to deploy database connection utilities in the mainnet environment.