### PR TITLE
Update UAT node images to v1.6.0

### DIFF
--- a/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-sequencer.yaml
+++ b/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-sequencer.yaml
@@ -6,8 +6,8 @@ global:
 enclave:
   replicaCount: 1
   image:
-    repository: testnetobscuronet.azurecr.io/obscuronet/uat_enclave
-    tag: "latest"
+    repository: testnetobscuronet.azurecr.io/obscuronet/enclave
+    tag: "v1.6.0"
   nodeSelector:
     kubernetes.io/hostname: aks-sgxpool-23126921-vmss000023
   secretEnv:
@@ -34,8 +34,8 @@ enclave02:
   enabled: true
   replicaCount: 1
   image:
-    repository: testnetobscuronet.azurecr.io/obscuronet/uat_enclave
-    tag: "latest"
+    repository: testnetobscuronet.azurecr.io/obscuronet/enclave
+    tag: "v1.6.0"
   nodeSelector:
     kubernetes.io/hostname: aks-sgxpool-23126921-vmss000024
   secretEnv:
@@ -61,8 +61,8 @@ enclave02:
 
 host:
   image:
-    repository: "testnetobscuronet.azurecr.io/obscuronet/uat_host"
-    tag: "latest"
+    repository: "testnetobscuronet.azurecr.io/obscuronet/host"
+    tag: "v1.6.0"
   fqdn: uat-testnet-sequencer.ten.xyz
   nodeSelector:
     kubernetes.io/hostname: aks-sgxpool-23126921-vmss000023

--- a/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-01.yaml
+++ b/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-01.yaml
@@ -5,8 +5,8 @@ global:
 
 enclave:
   image:
-    repository: testnetobscuronet.azurecr.io/obscuronet/uat_enclave
-    tag: "latest"
+    repository: testnetobscuronet.azurecr.io/obscuronet/enclave
+    tag: "v1.6.0"
   nodeSelector:
     kubernetes.io/hostname: aks-sgxpool-23126921-vmss000024
   secretEnv:
@@ -32,8 +32,8 @@ enclave:
   
 host:
   image:
-    repository: "testnetobscuronet.azurecr.io/obscuronet/uat_host"
-    tag: "latest"
+    repository: "testnetobscuronet.azurecr.io/obscuronet/host"
+    tag: "v1.6.0"
   fqdn: uat-validator-01.ten.xyz
   nodeSelector:
     kubernetes.io/hostname: aks-sgxpool-23126921-vmss000024

--- a/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-02.yaml
+++ b/nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-02.yaml
@@ -5,8 +5,8 @@ global:
 
 enclave:
   image:
-    repository: testnetobscuronet.azurecr.io/obscuronet/uat_enclave
-    tag: "latest"
+    repository: testnetobscuronet.azurecr.io/obscuronet/enclave
+    tag: "v1.6.0"
   nodeSelector:
     kubernetes.io/hostname: aks-sgxpool-23126921-vmss000025
   secretEnv:
@@ -32,8 +32,8 @@ enclave:
 
 host:
   image:
-    repository: "testnetobscuronet.azurecr.io/obscuronet/uat_host"
-    tag: "latest"
+    repository: "testnetobscuronet.azurecr.io/obscuronet/host"
+    tag: "v1.6.0"
   fqdn: uat-validator-02.ten.xyz
   nodeSelector:
     kubernetes.io/hostname: aks-sgxpool-23126921-vmss000025


### PR DESCRIPTION
## Overview
This PR updates the UAT nonprod environment node images to use v1.6.0 and changes from UAT-specific image repositories to the standard production repositories.

## Changes
- **Sequencer (uat-sequencer)**: Updated enclave and host images
- **Validator-01 (uat-validator-01)**: Updated enclave and host images  
- **Validator-02 (uat-validator-02)**: Updated enclave and host images

## Image Updates
### Enclave Images
- FROM: `testnetobscuronet.azurecr.io/obscuronet/uat_enclave:latest`
- TO: `testnetobscuronet.azurecr.io/obscuronet/enclave:v1.6.0`

### Host Images  
- FROM: `testnetobscuronet.azurecr.io/obscuronet/uat_host:latest`
- TO: `testnetobscuronet.azurecr.io/obscuronet/host:v1.6.0`

## Environments Affected
- **Environment**: UAT (nonprod)
- **Components**: sequencer, validator-01, validator-02

## Files Modified
- `nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-sequencer.yaml`
- `nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-01.yaml`
- `nonprod-argocd-config/apps/envs/uat/valuesFile/values-uat-validator-02.yaml`

## Deployment Notes
This update will trigger ArgoCD to deploy the new v1.6.0 node images to the UAT environment. The deployment should be monitored to ensure proper rollout.