### PR TITLE
Update Sepolia environment: v1.6.0 images, new node selectors, enable destructive deployment

### DIFF
--- a/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-dexynth-sepolia-gateway.yaml
+++ b/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-dexynth-sepolia-gateway.yaml
@@ -69,7 +69,7 @@ backend:
       sgx.intel.com/provision: 10
       sgx.intel.com/enclave: 10
   nodeSelector:
-      kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000f
+      kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000j
   tolerations: []
   affinity: {}
 

--- a/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-pentest-sepolia-gateway.yaml
+++ b/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-pentest-sepolia-gateway.yaml
@@ -69,7 +69,7 @@ backend:
       sgx.intel.com/provision: 10
       sgx.intel.com/enclave: 10
   nodeSelector:
-      kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000e
+      kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000i
   tolerations: []
   affinity: {}
 

--- a/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-gateway.yaml
+++ b/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-gateway.yaml
@@ -69,7 +69,7 @@ backend:
       sgx.intel.com/provision: 10
       sgx.intel.com/enclave: 10
   nodeSelector:
-      kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000h
+      kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000k
   tolerations: []
   affinity: {}
 

--- a/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-sequencer.yaml
+++ b/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-sequencer.yaml
@@ -1,7 +1,7 @@
 global:
   imagePullSecrets: []
   imagePullPolicy: Always
-  destructiveDeployment: false
+  destructiveDeployment: true
 
 enclave:
   replicaCount: 1
@@ -9,7 +9,7 @@ enclave:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.6.0"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000e
+    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000i
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -45,7 +45,7 @@ enclave02:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.6.0"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000f
+    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000j
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -82,7 +82,7 @@ host:
     tag: "v1.6.0"
   fqdn: sepolia-testnet-sequencer.ten.xyz
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000e
+    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000i
 
 config:
   network:

--- a/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-validator-01.yaml
+++ b/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-validator-01.yaml
@@ -1,14 +1,14 @@
 global:
   imagePullSecrets: []
   imagePullPolicy: Always
-  destructiveDeployment: false
+  destructiveDeployment: true
 
 enclave:
   image:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.6.0"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000h
+    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000k
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -44,7 +44,7 @@ host:
     tag: "v1.6.0"
   fqdn: sepolia-validator-01.ten.xyz
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000h
+    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000k
 
 config:
   network:

--- a/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-validator-02.yaml
+++ b/nonprod-argocd-config/apps/envs/sepolia/valuesFile/values-sepolia-validator-02.yaml
@@ -1,14 +1,14 @@
 global:
   imagePullSecrets: []
   imagePullPolicy: Always
-  destructiveDeployment: false
+  destructiveDeployment: true
 
 enclave:
   image:
     repository: testnetobscuronet.azurecr.io/obscuronet/enclave
     tag: "v1.6.0"
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000g
+    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000l
   secretEnv:
     ENCLAVE_DB_SQLITEPATH: ""
   edb:
@@ -44,7 +44,7 @@ host:
     tag: "v1.6.0"
   fqdn: sepolia-validator-02.ten.xyz
   nodeSelector:
-    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000g
+    kubernetes.io/hostname: aks-sgxpool-54727109-vmss00000l
 
 
 config:


### PR DESCRIPTION
## Summary
This PR updates the Sepolia environment configuration with the following changes:

### Changes Made:
- ✅ **Enclave and host images**: Already at v1.6.0 (no changes needed)
- ✅ **Destructive deployment**: Enabled for sequencer and validators
- ✅ **Node selectors**: Updated to new nodes as requested

### Node Selector Mappings:
| Component | Previous Node | New Node |
|-----------|---------------|----------|
| Sequencer enclave | vmss00000e | vmss00000i |
| Sequencer enclave02 | vmss00000f | vmss00000j |
| Sequencer host | vmss00000e | vmss00000i |
| Validator-01 enclave/host | vmss00000h | vmss00000k |
| Validator-02 enclave/host | vmss00000g | vmss00000l |
| Main Gateway | vmss00000h | vmss00000k |
| Dexynth Gateway | vmss00000f | vmss00000j |
| Pentest Gateway | vmss00000e | vmss00000i |

### Files Modified:
- `values-sepolia-sequencer.yaml`
- `values-sepolia-validator-01.yaml`
- `values-sepolia-validator-02.yaml`
- `values-sepolia-gateway.yaml`
- `values-dexynth-sepolia-gateway.yaml`
- `values-pentest-sepolia-gateway.yaml`

### Impact:
- All Sepolia environment apps will be redeployed with v1.6.0 images
- Workloads will be redistributed to the new node pool
- Destructive deployment enabled ensures clean state during deployment